### PR TITLE
Functionality to filter by CPE IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ An unofficial, RESTful API for NIST's NVD.
 *../year/(YEAR)* <br />
 *../recent* <br />
 *../modified* <br />
+*../cpe/(CPE-Version)/(CPE-ID matcher)* <br />
 you can also add a keyword search parameter to return only CVEs with <br />
 that keyword found in the description, for example:  <br />
 *https://plasticuproject.pythonanywhere.com/nvd-api/v1/year/2019?keyword=sudo* <br />

--- a/api/app.py
+++ b/api/app.py
@@ -29,6 +29,7 @@ search.CVE_Year.decorators.append(rate)
 search.CVE_Modified.decorators.append(rate)
 search.CVE_Recent.decorators.append(rate)
 search.CVE_All.decorators.append(rate)
+search.CVE_CPE.decorators.append(rate)
 search.Schema.decorators.append(rate)
 
 
@@ -38,6 +39,7 @@ api.add_resource(search.CVE_Year, '/nvd-api/v1/year/<year>')
 api.add_resource(search.CVE_Modified, '/nvd-api/v1/modified')
 api.add_resource(search.CVE_Recent, '/nvd-api/v1/recent')
 api.add_resource(search.CVE_All, '/nvd-api/v1/all')
+api.add_resource(search.CVE_CPE, '/nvd-api/v1/cpe/<cpe_version>/<cpe_id>')
 api.add_resource(search.Schema, '/nvd-api/v1/schema')
 
 

--- a/api/resources/search.py
+++ b/api/resources/search.py
@@ -36,6 +36,40 @@ def keyword_search(value, result):
                 keyword_results.append(cve)
     return keyword_results
 
+def cpe_search(value, result, version: str='23'):
+    """
+    Helper function to search for results with a matching CPE value
+    """
+    results = []
+    def find_leaves(nodes):
+        """
+        Recursive function to obtain all configuration leaves of a CVE's
+        configuration nodes.
+        """
+        leaves = []
+        for subnode in nodes:
+            if 'children' in subnode.keys():
+                leaves += find_leaves(subnode['children'])
+            elif 'cpe_match' in subnode.keys():
+                leaves += find_leaves(subnode['cpe_match'])
+            else:
+                leaves.append(subnode)
+        return leaves
+
+    for cve in result:
+        if 'configurations' not in cve:
+            continue
+        if 'nodes' not in cve['configurations']:
+            continue
+        leaves = find_leaves(cve['configurations']['nodes'])
+        for leaf in leaves:
+            key = 'cpe' + version + 'Uri'
+            if key in leaf.keys():
+                if value in leaf[key]:
+                    results.append(cve)
+    return results
+
+
 
 def check_year(year):
 
@@ -154,6 +188,29 @@ class CVE_All(Resource):
         if args['keyword'] == '':
             return result
         return keyword_search(args['keyword'].lower(), result)
+
+
+class CVE_CPE(Resource):
+    """Initiates the Database class, loads all CVE archive
+    file in memory and returns all CVE data in the file matching the given
+    CPE-ID and keyword argument in a JSON response via a GET request.
+    If no keyword is given it will return all CVEs matching the CPE-ID.
+    Besides the CPE-ID, also the CPE-Version (23/24/etc.) must be specified.
+    """
+
+    # For the rate limiter necorator
+    decorators = []
+
+    @use_args(keyword)
+    def get(self, args, cpe_version, cpe_id):
+        result = []
+        data = Database().data
+        for year in range(2002, 2022):  # Keep up-to-date with current year
+            for cve in data(str(year)):
+                result.append(cve)
+        if args['keyword'] != '':
+            result = keyword_search(args['keyword'].lower(), result)
+        return cpe_search(cpe_id, result, version=str(cpe_version))
 
 
 class Schema(Resource):


### PR DESCRIPTION
With this fork, I propose additional functionality to filter by [Common Platform Enumeration](https://nvd.nist.gov/products/cpe) Identifiers (CPE IDs).
CVE entries specify the CPE IDs of products that are affected by the vulnerability. With the additional filter, NVD_API can find all CVE entries of a given CPE ID. As it is the case with existing endpoints, ?keyword functionality is also provided.

CPE has multiple versions. The desired version is a part of the GET request:
```
/cpe/(CPE-Version)/(CPE-ID matcher)
```

The CPE-ID matcher constitutes the value that shall be searched for. A match is positive, if the specified value is part of a CPE's ID:  
`/cpe/23/iphone` matches the CPE ID `cpe:2.3:o:apple:iphone_os:*:*:*:*:*:*:*:*`